### PR TITLE
Fix parsing fallback for exported object rendering without class icinga2

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -268,8 +268,6 @@ Data type: `Array[String[1]]`
 
 List of features to activate. Defaults to [checker, mainlog, notification].
 
-Default value: `['checker', 'mainlog', 'notification']`
-
 ##### <a name="-icinga2--purge_features"></a>`purge_features`
 
 Data type: `Boolean`
@@ -291,8 +289,6 @@ Default value: `{}`
 Data type: `Array[String[1]]`
 
 A list of the ITL plugins to load. Defaults to [ 'plugins', 'plugins-contrib', 'windows-plugins', 'nscp' ].
-
-Default value: `['plugins', 'plugins-contrib', 'windows-plugins', 'nscp']`
 
 ##### <a name="-icinga2--confd"></a>`confd`
 
@@ -2775,6 +2771,7 @@ icinga2::config::fragment { 'load-function':
 The following parameters are available in the `icinga2::config::fragment` defined type:
 
 * [`content`](#-icinga2--config--fragment--content)
+* [`ensure`](#-icinga2--config--fragment--ensure)
 * [`target`](#-icinga2--config--fragment--target)
 * [`code_name`](#-icinga2--config--fragment--code_name)
 * [`order`](#-icinga2--config--fragment--order)
@@ -2784,6 +2781,14 @@ The following parameters are available in the `icinga2::config::fragment` define
 Data type: `String`
 
 Content to insert in file specified in target.
+
+##### <a name="-icinga2--config--fragment--ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+Set to present enables the fragment, absent disables it.
+
+Default value: `present`
 
 ##### <a name="-icinga2--config--fragment--target"></a>`target`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -268,6 +268,8 @@ Data type: `Array[String[1]]`
 
 List of features to activate. Defaults to [checker, mainlog, notification].
 
+Default value: `['checker', 'mainlog', 'notification']`
+
 ##### <a name="-icinga2--purge_features"></a>`purge_features`
 
 Data type: `Boolean`
@@ -289,6 +291,8 @@ Default value: `{}`
 Data type: `Array[String[1]]`
 
 A list of the ITL plugins to load. Defaults to [ 'plugins', 'plugins-contrib', 'windows-plugins', 'nscp' ].
+
+Default value: `['plugins', 'plugins-contrib', 'windows-plugins', 'nscp']`
 
 ##### <a name="-icinga2--confd"></a>`confd`
 

--- a/functions/parse.pp
+++ b/functions/parse.pp
@@ -28,7 +28,7 @@ function icinga2::parse(
   icinga2::icinga2_attributes(
     $attrs,
     concat($icinga2::globals::reserved, $reserved),
-    pick($icinga2::_constants, $icinga2::globals::constants) + $constants,
+    pick(getvar('icinga2::_constants'), $icinga2::globals::constants) + $constants,
     $indent
   )
 }

--- a/functions/parse.pp
+++ b/functions/parse.pp
@@ -28,7 +28,7 @@ function icinga2::parse(
   icinga2::icinga2_attributes(
     $attrs,
     concat($icinga2::globals::reserved, $reserved),
-    $icinga2::_constants + $constants,
+    pick($icinga2::_constants, $icinga2::globals::constants) + $constants,
     $indent
   )
 }

--- a/manifests/config/fragment.pp
+++ b/manifests/config/fragment.pp
@@ -34,6 +34,9 @@
 # @param content
 #   Content to insert in file specified in target.
 #
+# @param ensure
+#   Set to present enables the fragment, absent disables it.
+#
 # @param target
 #   Destination config file to store in this fragment. File will be declared the
 #   first time.
@@ -47,6 +50,7 @@
 define icinga2::config::fragment (
   String                       $content,
   Stdlib::Absolutepath         $target,
+  Enum['present', 'absent']    $ensure    = present,
   String                       $code_name = $title,
   Variant[String, Integer]     $order     = '00',
 ) {
@@ -67,9 +71,11 @@ define icinga2::config::fragment (
     }
   }
 
-  concat::fragment { "icinga2::config::${code_name}":
-    target  => $target,
-    content => icinga::newline($content),
-    order   => $order,
+  if $ensure != 'absent' {
+    concat::fragment { "icinga2::config::${code_name}":
+      target  => $target,
+      content => icinga::newline($content),
+      order   => $order,
+    }
   }
 }

--- a/manifests/object/apiuser.pp
+++ b/manifests/object/apiuser.pp
@@ -97,6 +97,7 @@ define icinga2::object::apiuser (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::ApiUser::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -79,6 +79,7 @@ define icinga2::object::checkcommand (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::CheckCommand::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -131,6 +131,7 @@ define icinga2::object::dependency (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::Dependency::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -65,6 +65,7 @@ define icinga2::object::endpoint (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::Endpoint::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $_target,

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -74,6 +74,7 @@ define icinga2::object::eventcommand (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::EventCommand::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -193,6 +193,7 @@ define icinga2::object::host (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::Host::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -72,6 +72,7 @@ define icinga2::object::hostgroup (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::HostGroup::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/icingaapplication.pp
+++ b/manifests/object/icingaapplication.pp
@@ -91,6 +91,7 @@ define icinga2::object::icingaapplication (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::IcingaApplication::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $_target,

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -146,6 +146,7 @@ define icinga2::object::notification (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::Notification::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -80,6 +80,7 @@ define icinga2::object::notificationcommand (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::NotificationCommand::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -101,6 +101,7 @@ define icinga2::object::scheduleddowntime (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::ScheduledDowntime::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -237,6 +237,7 @@ define icinga2::object::service (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::Service::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -70,6 +70,7 @@ define icinga2::object::servicegroup (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::ServiceGroup::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -75,6 +75,7 @@ define icinga2::object::timeperiod (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::TimePeriod::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -99,6 +99,7 @@ define icinga2::object::user (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::User::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -74,6 +74,7 @@ define icinga2::object::usergroup (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::UserGroup::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $target,

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -69,6 +69,7 @@ define icinga2::object::zone (
 
   unless empty($export) {
     @@icinga2::config::fragment { "icinga2::object::Zone::${title}":
+      ensure  => $ensure,
       tag     => prefix(any2array($export), 'icinga2::instance::'),
       content => epp('icinga2/object.conf.epp', $config),
       target  => $_target,

--- a/manifests/query_objects.pp
+++ b/manifests/query_objects.pp
@@ -34,10 +34,12 @@ class icinga2::query_objects (
 
   $file_list = $pql_query.map |$object| {
     $object['parameters']['target']
-  }.unique
+  }
 
-  $file_list.each |$target| {
-    $objects = $pql_query.filter |$object| { $target == $object['parameters']['target'] }
+  unique($file_list).each |$target| {
+    $objects = $pql_query.filter |$object| {
+      ($target == $object['parameters']['target']) and ($object['parameters']['ensure'] != 'absent')
+    }
 
     $_content = $objects.reduce('') |String $memo, $object| {
       "${memo}${object['parameters']['content']}"

--- a/manifests/query_objects.pp
+++ b/manifests/query_objects.pp
@@ -21,7 +21,7 @@ class icinga2::query_objects (
     'windows': {
     } # windows
     default: {
-      Concat {
+      File {
         owner   => $icinga2::globals::user,
         group   => $icinga2::globals::group,
         seltype => 'icinga2_etc_t',
@@ -32,31 +32,26 @@ class icinga2::query_objects (
 
   $pql_query =  puppetdb_query("resources[parameters] { ${_environments} type = 'Icinga2::Config::Fragment' and exported = true and tag = 'icinga2::instance::${destination}' and nodes { deactivated is null and expired is null } order by certname, title }")
 
-  $file_list = $pql_query.map |$object| {
-    $object['parameters']['target']
-  }
-
-  unique($file_list).each |$target| {
-    $objects = $pql_query.filter |$object| {
-      ($target == $object['parameters']['target']) and ($object['parameters']['ensure'] != 'absent')
+  $_files = $pql_query.reduce({}) |Hash $memo, Hash $object| {
+    $_parameters       = $object['parameters']
+    $_target           = $_parameters['target']
+    $_existing_content = $memo[$_target] ? {
+      undef   => '',
+      default => $memo[$_target]['content'],
+    }
+    $_content = $_parameters['ensure'] ? {
+      'absent' => $_existing_content,
+      default  => "${_existing_content}${_parameters['content']}",
     }
 
-    $_content = $objects.reduce('') |String $memo, $object| {
-      "${memo}${object['parameters']['content']}"
-    }
-
-    if !defined(Concat[$target]) {
-      concat { $target:
-        ensure => present,
-        tag    => 'icinga2::config::file',
-        warn   => true,
-      }
-    }
-
-    concat::fragment { "custom-${target}":
-      target  => $target,
-      content => $_content,
-      order   => 99,
+    $memo + {
+      $_target => {
+        'ensure'  => file,
+        'tag'     => 'icinga2::config::file',
+        'content' => $_content,
+      },
     }
   }
+
+  create_resources('file', $_files)
 }

--- a/templates/object.conf.epp
+++ b/templates/object.conf.epp
@@ -11,11 +11,12 @@
       Array $ignore = [],
 | -%>
 
+<% $_constants = pick(getvar('icinga2::_constants'), $icinga2::globals::constants) -%>
 <% $_attrs = $attrs + { 'assign where' => $assign, 'ignore where' => $ignore, } -%>
 <% if $apply =~ String { %>apply <%= $object_type -%>
 <% if $prefix { -%>
 <% if $prefix =~ String { %> "<%= $prefix %>"<% } else { -%>
-<% if $object_name in $icinga2::_constants { -%>
+<% if $object_name in $_constants { -%>
  <%= $object_name -%>
 <% } else { -%>
  "<%= $object_name -%>"<% } -%>
@@ -26,7 +27,7 @@
 <% if $apply { %>apply<% } else { -%>
 <% if $template { %>template<% } else { %>object<% } -%>
 <% } %> <%= $object_type -%>
-<% if $object_name in $icinga2::_constants { -%>
+<% if $object_name in $_constants { -%>
  <%= $object_name -%>
 <% } else { -%>
  "<%= $object_name %>"<% } -%>


### PR DESCRIPTION
## Summary

When `icinga2::object::*` is used with `export => 'master'`, the object
configuration is rendered on the source node. In this context,
`$icinga2::_constants` may be empty because `class icinga2` is not declared
on exporting nodes.

This causes `icinga2::parse()` to fail while merging constants.

## Fix

Use `icinga2::globals::constants` as a fallback when `$icinga2::_constants`
is not available.

## Context

This was encountered while migrating exported Host objects to the
`query_objects` export model introduced for large environments.

